### PR TITLE
Instruct annex to have only binary files under annex

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * annex.backend=MD5E
 **/.git* annex.largefiles=nothing
+* annex.largefiles=((mimeencoding=binary)and(largerthan=0))


### PR DESCRIPTION
otherwise  "datalad save"  would even save modified .md files as unlocked annexed files (happened to me with  "datalad run" command)